### PR TITLE
sanders: sepolicy: fix more denials

### DIFF
--- a/sepolicy/vendor/hal_keymaster_qti.te
+++ b/sepolicy/vendor/hal_keymaster_qti.te
@@ -1,0 +1,1 @@
+allow hal_keymaster_qti system_file:file read;

--- a/sepolicy/vendor/hal_memtrack_default.te
+++ b/sepolicy/vendor/hal_memtrack_default.te
@@ -1,0 +1,1 @@
+allow hal_memtrack_default sysfs_kgsl:lnk_file read;

--- a/sepolicy/vendor/netmgrd.te
+++ b/sepolicy/vendor/netmgrd.te
@@ -1,6 +1,5 @@
 allow netmgrd toolbox_exec:file { getattr read open };
-
 allow netmgrd init:unix_stream_socket connectto;
 allow netmgrd property_socket:sock_file write;
-allow netmgrd system_file:file lock;
+allow netmgrd system_file:file { execute lock };
 allow netmgrd default_prop:property_service set;

--- a/sepolicy/vendor/rmt_storage.te
+++ b/sepolicy/vendor/rmt_storage.te
@@ -8,6 +8,7 @@ allow rmt_storage debugfs_rmt_storage:file w_file_perms;
 
 allow rmt_storage fsg_file:file { open read };
 allow rmt_storage fsg_file:dir search;
+allow rmt_storage fsg_file:lnk_file read;
 
 allow rmt_storage self:capability dac_override;
 allow rmt_storage unlabeled:dir search;

--- a/sepolicy/vendor/system_server.te
+++ b/sepolicy/vendor/system_server.te
@@ -20,3 +20,5 @@ allow system_server sysfs:file{ open read };
 allow system_server vendor_file:file open;
 allow system_server adb_data_file:file { getattr open read };
 allow system_server dalvikcache_data_file:file { execute write };
+
+allow system_server persist_camera_prop:file read;

--- a/sepolicy/vendor/time_daemon.te
+++ b/sepolicy/vendor/time_daemon.te
@@ -1,3 +1,7 @@
 get_prop(time_daemon, diag_prop);
 
 allow time_daemon persist_file:file { open read write };
+
+allow time_daemon sysfs:file read;
+
+allow time_daemon time_daemon:capability { dac_override dac_read_search };


### PR DESCRIPTION
based on my personal guide:
log e.g.:
"avc: denied { permission type} for xxx=0="xxxxx" name="xxxxx" dev="xxxx" ino=xxxx scontext=u:r:file_name:s0 tcontext=u:object_r:permission_name:s0 tclass=permission_class permissive=0"

the fix e.g.:
allow file_name permission_name:permission_class { permission type }

denials on the log:
avc: denied { execute } for uid=0 name="tc" dev="mmcblk0p53" ino=869 scontext=u:r:netmgrd:s0 tcontext=u:object_r:system_file:s0 tclass=file permissive=0
avc: denied { execute } for uid=0 name="iptables" dev="mmcblk0p53" ino=703 scontext=u:r:netmgrd:s0 tcontext=u:object_r:system_file:s0 tclass=file permissive=0
avc: denied { execute } for uid=0 name="ip6tables" dev="mmcblk0p53" ino=698 scontext=u:r:netmgrd:s0 tcontext=u:object_r:system_file:s0 tclass=file permissive=0
avc: denied { read } for uid=1001 name="fsg" dev="mmcblk0p53" ino=27 scontext=u:r:rmt_storage:s0 tcontext=u:object_r:fsg_file:s0 tclass=lnk_file permissive=0
avc: denied { read } for uid=1001 name="fsg" dev="mmcblk0p53" ino=27 scontext=u:r:rmt_storage:s0 tcontext=u:object_r:fsg_file:s0 tclass=lnk_file permissive=0
avc: denied { read } for uid=1001 name="fsg" dev="mmcblk0p53" ino=27 scontext=u:r:rmt_storage:s0 tcontext=u:object_r:fsg_file:s0 tclass=lnk_file permissive=0
avc: denied { read } for uid=1001 name="fsg" dev="mmcblk0p53" ino=27 scontext=u:r:rmt_storage:s0 tcontext=u:object_r:fsg_file:s0 tclass=lnk_file permissive=0
avc: denied { read } for uid=1000 name="vendor.qti.hardware.cryptfshw@1.0.so" dev="mmcblk0p53" ino=3367 scontext=u:r:hal_keymaster_qti:s0 tcontext=u:object_r:system_file:s0 tclass=file permissive=0
avc: denied { write } for uid=0 name="tasks" dev="tmpfs" ino=1634 scontext=u:r:netd:s0 tcontext=u:object_r:device:s0 tclass=file permissive=0
avc: denied { read } for uid=0 name="name" dev="sysfs" ino=22770 scontext=u:r:time_daemon:s0 tcontext=u:object_r:sysfs:s0 tclass=file permissive=0
avc: denied { dac_override } for uid=0 capability=1 scontext=u:r:time_daemon:s0 tcontext=u:r:time_daemon:s0 tclass=capability permissive=0
avc: denied { dac_read_search } for uid=0 capability=2 scontext=u:r:time_daemon:s0 tcontext=u:r:time_daemon:s0 tclass=capability permissive=0
avc: denied { read } for uid=1000 name="kgsl" dev="sysfs" ino=23198 scontext=u:r:hal_memtrack_default:s0 tcontext=u:object_r:sysfs_kgsl:s0 tclass=lnk_file permissive=0
avc: denied { read } for uid=1000 name="kgsl" dev="sysfs" ino=23198 scontext=u:r:hal_memtrack_default:s0 tcontext=u:object_r:sysfs_kgsl:s0 tclass=lnk_file permissive=0
avc: denied { read } for uid=1000 name="u:object_r:persist_camera_prop:s0" dev="tmpfs" ino=11425 scontext=u:r:system_server:s0 tcontext=u:object_r:persist_camera_prop:s0 tclass=file permissive=0
avc: denied { read } for uid=1000 name="u:object_r:persist_camera_prop:s0" dev="tmpfs" ino=11425 scontext=u:r:system_server:s0 tcontext=u:object_r:persist_camera_prop:s0 tclass=file permissive=0
avc: denied { read } for uid=1000 name="u:object_r:persist_camera_prop:s0" dev="tmpfs" ino=11425 scontext=u:r:system_server:s0 tcontext=u:object_r:persist_camera_prop:s0 tclass=file permissive=0