### PR TITLE
sanders: rootdir: insmod DTV module only for XT1802

### DIFF
--- a/rootdir/etc/init.mmi.boot.sh
+++ b/rootdir/etc/init.mmi.boot.sh
@@ -42,6 +42,3 @@ if [ -f /sys/devices/soc0/select_image ]; then
     echo $image_variant > /sys/devices/soc0/image_variant
     echo $oem_version > /sys/devices/soc0/image_crm_version
 fi
-
-enable ecompassd
-insmod /vendor/lib/modules/isdbt.ko

--- a/rootdir/etc/init.qcom.rc
+++ b/rootdir/etc/init.qcom.rc
@@ -735,6 +735,9 @@ service iprenew_wigig0 /system/bin/dhcpcd -n
     disabled
     oneshot
 
+on property:ro.boot.hardware.sku=XT1802
+    insmod /vendor/lib/modules/isdbt.ko
+
 service wlan_logging /system/bin/cnss_diag -q -f
     class main
     user system


### PR DESCRIPTION
* Nuke ecompassd mentions because sensors.qti handles ecompass

Signed-off-by: JarlPenguin <jarlpenguin@outlook.com>